### PR TITLE
Added functionality to rename authors, to remove them or their aliases and to list authors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,30 @@ This command returns a list of all the quotes with quote IDs by the author.
 This command adds a new author. The authors are stored in AMBBQuotes.json. In order for this command to work you have to be an authorized user. (Have the proper role).
 
 
+### !renameAuthor [current Name] [new Name]
+This command renames the author in the AMBBQuotes.json file. In order for this command to work you have to be an authorized user. (Have the proper role).
+
+
+### !removeAuthor [Name]
+This command deletes the author entry from the AMBBQuotes.json file. This subsequently removes all of their quotes. In order for this command to work you have to be an authorized user. (Have the proper role).
+
+
 ### !addAlias [Name] [new Alias]
 This command adds a new alias to an author. The aliases for an author are stored in AMBBQuotes.json. In order for this command to work you have to be an authorized user. (Have the proper role). When using !addquote or !quotelist [Name] you can also use one of the aliases of a user instead of the original name.
+
+
+### !removeAlias [Alias]
+This command removes the alias from the author it's attached to. In order for this command to work you have to be an authorized user. (Have the proper role).
+
+
+### !authorlist
+This command will list all the authors in the AMBBQuotes.json file sorted by number of quotes.
+
+#### !authorlist [count]
+This command will list [count] authors from the AMBBQuotes.json file sorted by number of quotes.
+
+#### !authorlist top [count]
+This command will list all the authors that are in the top [count] by number of quotes.
 
 
 ### !quoteQuiz

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ This command adds a quote. The quotes are stored in AMBBQuotes.json. In order fo
 
 
 ### !removequote
-This command removes the last added quote.
+This command removes the last added quote. In order for this command to work you have to be an authorized user. (Have the proper role).
 
 #### !removequote [Quote ID]
-This command removes the quote associated with the ID.
+This command removes the quote associated with the ID. In order for this command to work you have to be an authorized user. (Have the proper role).
 
 
 ### !fixquote [New Quote Text]
-This command edits the quote text of the last added quote.
+This command edits the quote text of the last added quote. In order for this command to work you have to be an authorized user. (Have the proper role).
 
 #### !fixquote [Quote ID] [New Quote Text]
-This command edits the quote text of the quote associated with the ID.
+This command edits the quote text of the quote associated with the ID. In order for this command to work you have to be an authorized user. (Have the proper role).
 
 
 ### !quotelist

--- a/src/main/java/attmayMBBot/commands/CommandsCommand.java
+++ b/src/main/java/attmayMBBot/commands/CommandsCommand.java
@@ -5,6 +5,6 @@ import discord4j.core.object.entity.Message;
 public class CommandsCommand implements ICommand{
     @Override
     public void execute(Message message, String[] args) {
-        message.getChannel().block().createMessage("You can find a list of all the commands on the github page for this project:\nhttps://github.com/Woodmaninator/AttmayMBBot").block();
+        message.getChannel().block().createMessage("You can find a list of all the commands on the github page for this project:\nhttps://github.com/Woodmaninator/AttmayMBBot#commands").block();
     }
 }

--- a/src/main/java/attmayMBBot/commands/quoteCommand/AllAuthorsCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/AllAuthorsCommand.java
@@ -1,0 +1,111 @@
+package attmayMBBot.commands.quoteCommand;
+
+import attmayMBBot.commands.ICommand;
+import attmayMBBot.config.AttmayMBBotConfig;
+import attmayMBBot.functionalities.quoteManagement.QuoteAuthor;
+import attmayMBBot.functionalities.quoteManagement.QuoteManager;
+import discord4j.core.object.entity.Message;
+import discord4j.rest.util.Color;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AllAuthorsCommand implements ICommand {
+    private AttmayMBBotConfig config;
+    private QuoteManager quoteManager;
+
+    public AllAuthorsCommand(AttmayMBBotConfig config, QuoteManager quoteManager){
+        this.config = config;
+        this.quoteManager = quoteManager;
+    }
+
+    @Override
+    public void execute(Message message, String[] args) {
+        List<QuoteAuthor> authorList;
+        List<String> embedDescriptions = new ArrayList<>();
+        String embedTitle = "List of all Quote Authors";
+        StringBuilder sb = new StringBuilder();
+        final int MAX_EMBED_CAPACITY = 4096;
+
+        // check if there are any quotes authors
+        if (quoteManager.getQuoteAuthors().size() == 0) {
+            message.getChannel().block().createMessage("There are no quote authors to list!").block();
+            return;
+        }
+
+        // sort quote authors in number of quotes
+        Comparator<QuoteAuthor> authorComparator = (QuoteAuthor a, QuoteAuthor b) -> ((Integer)b.getQuotes().size()).compareTo(a.getQuotes().size());
+        authorList = quoteManager.getQuoteAuthors().stream().sorted(authorComparator).collect(Collectors.toList());
+
+        int lastGoodIndex = 0;
+        for (int i = 0; i < authorList.size(); ++i) {
+            // get current author
+            QuoteAuthor author = authorList.get(i);
+
+            // update last good index
+            lastGoodIndex = sb.length();
+
+            // start with author place
+            sb.append(i);
+            sb.append(". ");
+            sb.append(author.getName());
+
+            // begin alias list
+            if (author.getAliases().size() > 0) {
+                sb.append(" (A.K.A. ");
+                // count how many commas there should be
+                int commas = author.getAliases().size();
+                for (String alias : author.getAliases()) {
+                    // append the alias
+                    sb.append(alias);
+                    // add a comma if needed
+                    if (--commas > 0) {
+                        sb.append(", ");
+                    }
+                }
+                // close parenthesis
+                sb.append(")");
+            }
+
+            // append quote count
+            sb.append(" has ");
+            sb.append(author.getQuotes().size());
+            if (author.getQuotes().size() != 1) {
+                sb.append(" quotes.");
+            } else {
+                sb.append(" quote.");
+            }
+
+            // append new line
+            if (i != authorList.size()-1) {
+                sb.append("\n");
+            }
+
+            // check if exceeded capacity
+            if (sb.length() > MAX_EMBED_CAPACITY) {
+                // add everything up to this author to an embed description
+                embedDescriptions.add(sb.substring(0, lastGoodIndex));
+                // remove previous author entries
+                sb.delete(0, lastGoodIndex);
+            }
+        }
+
+        // add last embed description
+        if (sb.length() > 0) {
+            embedDescriptions.add(sb.toString());
+        }
+
+        // yeet the results out
+        for (String embedDescription : embedDescriptions) {
+            message.getChannel()
+                    .block()
+                    .createMessage(y -> {
+                       y.setEmbed(x -> {
+                           x.setTitle(embedTitle).setDescription(embedDescription).setColor(Color.of(0, 102, 102));
+                       });
+                    }).block();
+        }
+    }
+}

--- a/src/main/java/attmayMBBot/commands/quoteCommand/AllAuthorsCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/AllAuthorsCommand.java
@@ -16,9 +16,12 @@ public class AllAuthorsCommand implements ICommand {
     private AttmayMBBotConfig config;
     private QuoteManager quoteManager;
 
+    private Comparator<QuoteAuthor> authorComparator;
+
     public AllAuthorsCommand(AttmayMBBotConfig config, QuoteManager quoteManager){
         this.config = config;
         this.quoteManager = quoteManager;
+        this.authorComparator = (QuoteAuthor a, QuoteAuthor b) -> Integer.compare(b.getQuotes().size(), a.getQuotes().size());
     }
 
     @Override
@@ -28,36 +31,112 @@ public class AllAuthorsCommand implements ICommand {
         String embedTitle = "List of all Quote Authors";
         StringBuilder sb = new StringBuilder();
         final int MAX_EMBED_CAPACITY = 4096;
+        int maxPlaceCount = quoteManager.getQuoteAuthors().size();
+        int maxAuthorsCount = quoteManager.getQuoteAuthors().size();
 
         // check if there are any quotes authors
-        if (quoteManager.getQuoteAuthors().size() == 0) {
+        if (maxPlaceCount == 0) {
             message.getChannel().block().createMessage("There are no quote authors to list!").block();
             return;
         }
 
         // sort quote authors in number of quotes
-        Comparator<QuoteAuthor> authorComparator = (QuoteAuthor a, QuoteAuthor b) -> ((Integer)b.getQuotes().size()).compareTo(a.getQuotes().size());
-        authorList = quoteManager.getQuoteAuthors().stream().sorted(authorComparator).collect(Collectors.toList());
+        authorList = quoteManager.getQuoteAuthors().stream().sorted(this.authorComparator).collect(Collectors.toList());
 
-        int lastGoodIndex = 0;
-        for (int i = 0; i < authorList.size(); ++i) {
+        // check if there is an author count provided
+        if (args.length > 1) {
+            if (args[1].equalsIgnoreCase("top")) {
+                // command is !authorlist top [place]
+                if (args.length < 3) {
+                    message.getChannel()
+                            .block()
+                            .createMessage("This command feels incomplete.\nUse !authorlist top [place] instead.")
+                            .block();
+                    return;
+                }
+
+                // parse the [place] in !authorlist top [place]
+                try {
+                    maxPlaceCount = Math.min(Integer.parseInt(args[2]), maxPlaceCount);
+
+                    if (maxPlaceCount <= 0) {
+                        // invalid count
+                        message.getChannel()
+                                .block()
+                                .createMessage(":face_with_raised_eyebrow:")
+                                .block();
+                        return;
+                    }
+                } catch (Exception e) {
+                    // not a number
+                    message.getChannel()
+                            .block()
+                            .createMessage("Not a valid place number.")
+                            .block();
+                    return;
+                }
+            } else {
+                // command is !authorlist [count]
+                try {
+                    maxAuthorsCount = Math.min(Integer.parseInt(args[1]), maxAuthorsCount);
+
+                    if (maxAuthorsCount <= 0) {
+                        // invalid count
+                        message.getChannel()
+                                .block()
+                                .createMessage(":face_with_raised_eyebrow:")
+                                .block();
+                        return;
+                    }
+                } catch (Exception e) {
+                    // not a number
+                    message.getChannel()
+                            .block()
+                            .createMessage("Not a valid count.")
+                            .block();
+                    return;
+                }
+            }
+        }
+
+        int lastGoodLength;
+        int lastPlaceNumber = 1;
+        int lastPlaceIndex = 0;
+        int listedAuthorCount = 0;
+        for (int i = 0; i < maxAuthorsCount; ++i) {
             // get current author
-            QuoteAuthor author = authorList.get(i);
+            QuoteAuthor currentAuthor = authorList.get(i);
+            QuoteAuthor lastPlaceAuthor = authorList.get(lastPlaceIndex);
+
+            // update place number
+            if (currentAuthor.getQuotes().size() < lastPlaceAuthor.getQuotes().size()) {
+                ++lastPlaceNumber;
+                lastPlaceIndex = i;
+            }
+
+            // check if the desired count is reached
+            if (lastPlaceNumber > maxPlaceCount) {
+                --lastPlaceNumber;
+                break;
+            }
 
             // update last good index
-            lastGoodIndex = sb.length();
+            lastGoodLength = sb.length();
 
             // start with author place
-            sb.append(i);
-            sb.append(". ");
-            sb.append(author.getName());
+            sb.append("#");
+            sb.append(lastPlaceNumber);
+            sb.append(" ");
+
+            // append author name
+            sb.append(currentAuthor.getName());
 
             // begin alias list
-            if (author.getAliases().size() > 0) {
+            if (currentAuthor.getAliases().size() > 0) {
                 sb.append(" (A.K.A. ");
                 // count how many commas there should be
-                int commas = author.getAliases().size();
-                for (String alias : author.getAliases()) {
+                int commas = currentAuthor.getAliases().size();
+                for (String alias : currentAuthor.getAliases()) {
                     // append the alias
                     sb.append(alias);
                     // add a comma if needed
@@ -71,25 +150,28 @@ public class AllAuthorsCommand implements ICommand {
 
             // append quote count
             sb.append(" has ");
-            sb.append(author.getQuotes().size());
-            if (author.getQuotes().size() != 1) {
+            sb.append(currentAuthor.getQuotes().size());
+            if (currentAuthor.getQuotes().size() != 1) {
                 sb.append(" quotes.");
             } else {
                 sb.append(" quote.");
             }
 
             // append new line
-            if (i != authorList.size()-1) {
+            if (i != maxAuthorsCount-1) {
                 sb.append("\n");
             }
 
             // check if exceeded capacity
             if (sb.length() > MAX_EMBED_CAPACITY) {
                 // add everything up to this author to an embed description
-                embedDescriptions.add(sb.substring(0, lastGoodIndex));
+                embedDescriptions.add(sb.substring(0, lastGoodLength));
                 // remove previous author entries
-                sb.delete(0, lastGoodIndex);
+                sb.delete(0, lastGoodLength);
             }
+
+            // update listed author count
+            ++listedAuthorCount;
         }
 
         // add last embed description
@@ -97,13 +179,19 @@ public class AllAuthorsCommand implements ICommand {
             embedDescriptions.add(sb.toString());
         }
 
+        // update the embed title
+        if (listedAuthorCount < authorList.size()) {
+            embedTitle = String.format("List of the Top %d Quote Authors", lastPlaceNumber);
+        }
+
         // yeet the results out
+        String finalEmbedTitle = embedTitle;
         for (String embedDescription : embedDescriptions) {
             message.getChannel()
                     .block()
                     .createMessage(y -> {
                        y.setEmbed(x -> {
-                           x.setTitle(embedTitle).setDescription(embedDescription).setColor(Color.of(0, 102, 102));
+                           x.setTitle(finalEmbedTitle).setDescription(embedDescription).setColor(Color.of(0, 102, 102));
                        });
                     }).block();
         }

--- a/src/main/java/attmayMBBot/commands/quoteCommand/AllQuoteIDsCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/AllQuoteIDsCommand.java
@@ -63,7 +63,7 @@ public class AllQuoteIDsCommand implements ICommand {
             // In case the first embedDescriptions is full (limit of 4096), start another one and create a new StringBuilder instance.
             // The description gets stored in the embedDescription list.
             embedDescriptions.add(sb.toString());
-            sb = new StringBuilder(nextQuote + "\n\n");
+            sb = new StringBuilder(nextQuote);
         }
 
         // After every quote is done, add the last string in the StringBuilder to the list,

--- a/src/main/java/attmayMBBot/commands/quoteCommand/RemoveQuoteAuthorAliasCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/RemoveQuoteAuthorAliasCommand.java
@@ -1,0 +1,77 @@
+package attmayMBBot.commands.quoteCommand;
+
+import attmayMBBot.authorization.AdvancedBotUserAuthorization;
+import attmayMBBot.commands.ICommand;
+import attmayMBBot.config.AttmayMBBotConfig;
+import attmayMBBot.functionalities.quoteManagement.QuoteAuthor;
+import attmayMBBot.functionalities.quoteManagement.QuoteManager;
+import discord4j.core.object.entity.Message;
+
+import java.util.Optional;
+
+// intended command usage: !removealias [author alias]
+
+public class RemoveQuoteAuthorAliasCommand implements ICommand {
+    private AttmayMBBotConfig config;
+    private QuoteManager quoteManager;
+
+    public RemoveQuoteAuthorAliasCommand(AttmayMBBotConfig config, QuoteManager quoteManager) {
+        this.config = config;
+        this.quoteManager = quoteManager;
+    }
+
+    @Override
+    public void execute(Message message, String[] args) {
+        AdvancedBotUserAuthorization authorization = new AdvancedBotUserAuthorization(config);
+        String alias;
+
+        // authorized user check
+        if (!authorization.checkIfUserIsAuthorized(message.getAuthor().get())) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Well, I know this is somewhat awkward but you are not allowed to perform this command.")
+                    .block();
+            return;
+        }
+
+        // check argument count
+        if (args.length < 2) {
+            message.getChannel()
+                    .block()
+                    .createMessage("This command feels incomplete.\nUse !removealias [Alias] instead.")
+                    .block();
+            return;
+        }
+
+        // get alias
+        alias = args[1];
+
+        Optional<QuoteAuthor> opt_aliasOwner = removeAlias(alias);
+        if (!opt_aliasOwner.isPresent()) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Who? :face_with_raised_eyebrow:")
+                    .block();
+            return;
+        }
+
+        // save changes
+        quoteManager.saveQuotesToFile();
+
+        // report success
+        message.getChannel()
+                .block()
+                .createMessage(String.format("Successfully removed %s's alias \"%s\"", opt_aliasOwner.get().getName(), alias))
+                .block();
+    }
+
+    private Optional<QuoteAuthor> removeAlias(String alias) {
+        for (QuoteAuthor author : quoteManager.getQuoteAuthors()) {
+            if (author.getAliases().removeIf(authorAlias -> authorAlias.equalsIgnoreCase(alias))) {
+                return Optional.of(author);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/attmayMBBot/commands/quoteCommand/RemoveQuoteAuthorCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/RemoveQuoteAuthorCommand.java
@@ -1,0 +1,64 @@
+package attmayMBBot.commands.quoteCommand;
+
+import attmayMBBot.authorization.AdvancedBotUserAuthorization;
+import attmayMBBot.commands.ICommand;
+import attmayMBBot.config.AttmayMBBotConfig;
+import attmayMBBot.functionalities.quoteManagement.QuoteManager;
+import discord4j.core.object.entity.Message;
+
+// intended command usage: !removeauthor [author name]
+
+public class RemoveQuoteAuthorCommand implements ICommand {
+    private AttmayMBBotConfig config;
+    private QuoteManager quoteManager;
+
+    public RemoveQuoteAuthorCommand(AttmayMBBotConfig config, QuoteManager quoteManager) {
+        this.config = config;
+        this.quoteManager = quoteManager;
+    }
+
+    @Override
+    public void execute(Message message, String[] args) {
+        AdvancedBotUserAuthorization authorization = new AdvancedBotUserAuthorization(config);
+        String authorName;
+
+        // authorized user check
+        if (!authorization.checkIfUserIsAuthorized(message.getAuthor().get())) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Well, I know this is somewhat awkward but you are not allowed to perform this command.")
+                    .block();
+            return;
+        }
+
+        // check argument count
+        if (args.length < 2) {
+            message.getChannel()
+                    .block()
+                    .createMessage("This command feels incomplete.\nUse !removeauthor [Author username] instead.")
+                    .block();
+            return;
+        }
+
+        // get author name
+        authorName = args[1];
+
+        // attempt remove author
+        if (!quoteManager.getQuoteAuthors().removeIf(author -> author.getName().equalsIgnoreCase(authorName))) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Who? :face_with_raised_eyebrow:")
+                    .block();
+            return;
+        }
+
+        // save changes
+        quoteManager.saveQuotesToFile();
+
+        // report success
+        message.getChannel()
+                .block()
+                .createMessage(String.format("Author \"%s\" and their quotes have successfully been removed!", authorName))
+                .block();
+    }
+}

--- a/src/main/java/attmayMBBot/commands/quoteCommand/RenameQuoteAuthorCommand.java
+++ b/src/main/java/attmayMBBot/commands/quoteCommand/RenameQuoteAuthorCommand.java
@@ -1,0 +1,69 @@
+package attmayMBBot.commands.quoteCommand;
+
+import attmayMBBot.authorization.AdvancedBotUserAuthorization;
+import attmayMBBot.commands.ICommand;
+import attmayMBBot.config.AttmayMBBotConfig;
+import attmayMBBot.functionalities.quoteManagement.QuoteAuthor;
+import attmayMBBot.functionalities.quoteManagement.QuoteManager;
+import discord4j.core.object.entity.Message;
+
+// intended command usage: !renameauthor [current name] [new name]
+
+public class RenameQuoteAuthorCommand implements ICommand {
+    private AttmayMBBotConfig config;
+    private QuoteManager quoteManager;
+
+    public RenameQuoteAuthorCommand(AttmayMBBotConfig config, QuoteManager quoteManager) {
+        this.config = config;
+        this.quoteManager = quoteManager;
+    }
+
+    @Override
+    public void execute(Message message, String[] args) {
+        AdvancedBotUserAuthorization authorization = new AdvancedBotUserAuthorization(config);
+        String currentAuthorName;
+        String newAuthorName;
+
+        // authorized user check
+        if (!authorization.checkIfUserIsAuthorized(message.getAuthor().get())) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Well, I know this is somewhat awkward but you are not allowed to perform this command.")
+                    .block();
+            return;
+        }
+
+        // check argument count
+        if (args.length < 3) {
+            message.getChannel()
+                    .block()
+                    .createMessage("This command feels incomplete.\nUse !renameauthor [Author username] [New author name] instead.")
+                    .block();
+            return;
+        }
+        currentAuthorName = args[1];
+        newAuthorName = args[2];
+
+        // find author by name
+        QuoteAuthor author = quoteManager.getAuthorFromName(currentAuthorName);
+        if (author == null) {
+            message.getChannel()
+                    .block()
+                    .createMessage("Who? :face_with_raised_eyebrow:")
+                    .block();
+            return;
+        }
+
+        // rename author
+        author.setName(newAuthorName);
+
+        // save changes
+        quoteManager.saveQuotesToFile();
+
+        // report success
+        message.getChannel()
+                .block()
+                .createMessage(String.format("Author \"%s\" successfully renamed to \"%s\"!", currentAuthorName, newAuthorName))
+                .block();
+    }
+}

--- a/src/main/java/attmayMBBot/functionalities/quoteManagement/QuoteAuthor.java
+++ b/src/main/java/attmayMBBot/functionalities/quoteManagement/QuoteAuthor.java
@@ -33,4 +33,7 @@ public class QuoteAuthor {
     public List<Quote> getQuotes() {
         return quotes;
     }
+
+    //Setters
+    public void setName(String name) { this.name = name; }
 }

--- a/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
+++ b/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
@@ -47,6 +47,7 @@ public class CommandInterpreter {
         this.commandMap.put("!renameauthor", new RenameQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!removeauthor", new RemoveQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!addalias", new AddQuoteAuthorAliasCommand(config, quoteManager));
+        this.commandMap.put("!removealias", new RemoveQuoteAuthorAliasCommand(config, quoteManager));
         this.commandMap.put("!quotequiz", new QuoteQuizCommand(config, quoteQuizManager));
         this.commandMap.put("!commands", new CommandsCommand());
         this.commandMap.put("!aline", new AlineCommand(config, arcadeGameManager));

--- a/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
+++ b/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
@@ -46,6 +46,7 @@ public class CommandInterpreter {
         this.commandMap.put("!addauthor", new AddQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!renameauthor", new RenameQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!removeauthor", new RemoveQuoteAuthorCommand(config, quoteManager));
+        this.commandMap.put("!authorlist", new AllAuthorsCommand(config, quoteManager));
         this.commandMap.put("!addalias", new AddQuoteAuthorAliasCommand(config, quoteManager));
         this.commandMap.put("!removealias", new RemoveQuoteAuthorAliasCommand(config, quoteManager));
         this.commandMap.put("!quotequiz", new QuoteQuizCommand(config, quoteQuizManager));

--- a/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
+++ b/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
@@ -45,6 +45,7 @@ public class CommandInterpreter {
         this.commandMap.put("!uwu", new UwUCommand(config));
         this.commandMap.put("!addauthor", new AddQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!renameauthor", new RenameQuoteAuthorCommand(config, quoteManager));
+        this.commandMap.put("!removeauthor", new RemoveQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!addalias", new AddQuoteAuthorAliasCommand(config, quoteManager));
         this.commandMap.put("!quotequiz", new QuoteQuizCommand(config, quoteQuizManager));
         this.commandMap.put("!commands", new CommandsCommand());

--- a/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
+++ b/src/main/java/attmayMBBot/messageInterpreters/CommandInterpreter.java
@@ -44,6 +44,7 @@ public class CommandInterpreter {
         this.commandMap.put("!dinnerpost", new DinnerpostCommand(config));
         this.commandMap.put("!uwu", new UwUCommand(config));
         this.commandMap.put("!addauthor", new AddQuoteAuthorCommand(config, quoteManager));
+        this.commandMap.put("!renameauthor", new RenameQuoteAuthorCommand(config, quoteManager));
         this.commandMap.put("!addalias", new AddQuoteAuthorAliasCommand(config, quoteManager));
         this.commandMap.put("!quotequiz", new QuoteQuizCommand(config, quoteQuizManager));
         this.commandMap.put("!commands", new CommandsCommand());


### PR DESCRIPTION
### New commands:

- `!renameauthor [current Name] [new Name]` renames the author in the AMBBQuotes.json file. 

- `!removeauthor [Name]` deletes the author entry from the AMBBQuotes.json file.

- `!removealias [Alias]` removes the alias from the author it's attached to.

- `!authorlist` will list all the authors in the AMBBQuotes.json file sorted by number of quotes.
- `!authorlist [count]` will list `[count]` authors from the AMBBQuotes.json file sorted by number of quotes.
- `!authorlist top [count]` will list all the authors that are in the top `[count]` by number of quotes.

### Fixes:

- Fixed the unnecessary white-space after an embed split in `!quoteidlist`

### Changes:

- Changed !commands link to the [commands list](https://github.com/Woodmaninator/AttmayMBBot#commands) in this repository's README file

- Updated my old README to include the authorized user requirement (`"In order for this command to work you have to be an authorized user. (Have the proper role)."`)
- Updated the README to include new commands

### Notes:

I originally intended for `!renameAuthor` and `!removeauthor` to use the Discord IDs of the authors, but I quickly discovered that all the Discord IDs in our AMBBQuotes.json file were out-of-date. If Discord IDs were to change again, it would be difficult to use these commands. That is why I decided to use usernames, since there's already a check against duplicate usernames.